### PR TITLE
feat: add Atlas Cloud LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
 # App
 DATABASE_URL=file:./data/aicomic.db
 UPLOAD_DIR=./uploads
+
+# Atlas Cloud OpenAI-compatible LLM provider
+# ATLASCLOUD_API_KEY=
+# ATLASCLOUD_BASE_URL=https://api.atlascloud.ai/v1
+# ATLASCLOUD_MODEL=deepseek-ai/deepseek-v4-pro

--- a/src/components/settings/provider-form.tsx
+++ b/src/components/settings/provider-form.tsx
@@ -15,6 +15,7 @@ import { Loader2, Download, Plus, Eye, EyeOff, Trash2, Search } from "lucide-rea
 
 const DEFAULT_BASE_URLS: Record<Protocol, string> = {
   openai: "https://api.openai.com",
+  atlascloud: "https://api.atlascloud.ai/v1",
   gemini: "https://generativelanguage.googleapis.com",
   seedance: "https://ark.cn-beijing.volces.com",
   "ucloud-seedance": "https://api.modelverse.cn",
@@ -27,6 +28,7 @@ function getProtocolOptions(capability: Capability): { value: Protocol; label: s
   if (capability === "text") {
     return [
       { value: "openai", label: "OpenAI" },
+      { value: "atlascloud", label: "Atlas Cloud" },
       { value: "gemini", label: "Gemini" },
     ];
   }

--- a/src/lib/ai/ai-sdk.ts
+++ b/src/lib/ai/ai-sdk.ts
@@ -12,7 +12,8 @@ export interface ProviderConfig {
 
 export function createLanguageModel(config: ProviderConfig): LanguageModel {
   switch (config.protocol) {
-    case "openai": {
+    case "openai":
+    case "atlascloud": {
       const provider = createOpenAI({
         apiKey: config.apiKey,
         baseURL: config.baseUrl,

--- a/src/lib/ai/provider-factory.ts
+++ b/src/lib/ai/provider-factory.ts
@@ -27,6 +27,7 @@ export interface ModelConfigPayload {
 export function createAIProvider(config: ProviderConfig, uploadDir?: string): AIProvider {
   switch (config.protocol) {
     case "openai":
+    case "atlascloud":
       return new OpenAIProvider({
         apiKey: config.apiKey,
         baseURL: config.baseUrl,

--- a/src/lib/ai/setup.ts
+++ b/src/lib/ai/setup.ts
@@ -5,6 +5,11 @@ import { SeedanceProvider } from "./providers/seedance";
 
 let initialized = false;
 
+const ATLASCLOUD_BASE_URL =
+  process.env.ATLASCLOUD_BASE_URL || "https://api.atlascloud.ai/v1";
+const ATLASCLOUD_MODEL =
+  process.env.ATLASCLOUD_MODEL || "deepseek-ai/deepseek-v4-pro";
+
 export function initializeProviders() {
   if (initialized) return;
 
@@ -17,6 +22,21 @@ export function initializeProviders() {
     setDefaultAIProvider(
       new GeminiProvider(),
       (uploadDir) => new GeminiProvider({ ...(uploadDir && { uploadDir }) }),
+    );
+  } else if (process.env.ATLASCLOUD_API_KEY) {
+    setDefaultAIProvider(
+      new OpenAIProvider({
+        apiKey: process.env.ATLASCLOUD_API_KEY,
+        baseURL: ATLASCLOUD_BASE_URL,
+        model: ATLASCLOUD_MODEL,
+      }),
+      (uploadDir) =>
+        new OpenAIProvider({
+          apiKey: process.env.ATLASCLOUD_API_KEY,
+          baseURL: ATLASCLOUD_BASE_URL,
+          model: ATLASCLOUD_MODEL,
+          ...(uploadDir && { uploadDir }),
+        }),
     );
   }
 

--- a/src/stores/model-store.ts
+++ b/src/stores/model-store.ts
@@ -2,7 +2,15 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import { id as genId } from "@/lib/id";
 
-export type Protocol = "openai" | "gemini" | "seedance" | "ucloud-seedance" | "kling" | "wan" | "dashscope";
+export type Protocol =
+  | "openai"
+  | "atlascloud"
+  | "gemini"
+  | "seedance"
+  | "ucloud-seedance"
+  | "kling"
+  | "wan"
+  | "dashscope";
 export type Capability = "text" | "image" | "video";
 
 export interface Model {


### PR DESCRIPTION
## Summary
- add Atlas Cloud as a first-class text provider in model settings
- route Atlas Cloud through the existing OpenAI-compatible runtime paths
- support `ATLASCLOUD_API_KEY`, base URL, and model defaults for server configuration

## Validation
- `tsc --noEmit`
- focused ESLint on all changed TypeScript files
- Atlas model catalog: HTTP 200 and default model present
- live `createLanguageModel` Atlas completion: HTTP 200
- `git diff --check`

`next build` reached compilation but could not download the project's Google Fonts (`Karla`, `JetBrains Mono`, and `Playfair Display`) from this environment.